### PR TITLE
Armstrong-Numbers exercise is now not unlocked by another exercise.

### DIFF
--- a/config.json
+++ b/config.json
@@ -47,7 +47,7 @@
                 "math"
             ],
             "difficulty": 1,
-            "unlocked_by": "3d46c4cd-c909-43b6-a8b1-6739e3f38387",
+            "unlocked_by": null,
             "core": false,
             "uuid": "c214793e-0971-4aa5-9d0e-e31e3971b0b4",
             "slug": "armstrong-numbers"


### PR DESCRIPTION
While I work on a exercise path for Track, this will suffice for a quick launch.